### PR TITLE
fix: Ensure container runnable in deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM sslhep/analysis-dask-base:24.2.26
 
 LABEL maintainer Ilija Vukotic <ivukotic@cern.ch>
 
+SHELL [ "/bin/bash", "-c" ]
+
 USER root
 
 RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
@@ -14,7 +16,9 @@ COPY run.sh         /.run
 RUN chmod +x /.run
 
 RUN mkdir /workspace
-COPY private_jupyter_notebook_config.py /usr/local/etc/jupyter_notebook_config.py
+# Want this to go to $(jupyter --config-dir) which is /root/.jupyter for this container
+# c.f. https://docs.jupyter.org/en/latest/use/jupyter-directories.html#configuration-files
+COPY private_jupyter_notebook_config.py /root/.jupyter/jupyter_notebook_config.py
 
 RUN . /release_setup.sh \
     && /venv/bin/jupyter server extension enable --py jupyterlab --sys-prefix

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sslhep/analysis-dask-base:main
+FROM sslhep/analysis-dask-base:24.2.26
 
 LABEL maintainer Ilija Vukotic <ivukotic@cern.ch>
 
@@ -16,9 +16,8 @@ RUN chmod +x /.run
 RUN mkdir /workspace
 COPY private_jupyter_notebook_config.py /usr/local/etc/jupyter_notebook_config.py
 
-RUN . /release_setup.sh
-
-RUN /venv/bin/jupyter server extension enable --py jupyterlab --sys-prefix
+RUN . /release_setup.sh \
+    && /venv/bin/jupyter server extension enable --py jupyterlab --sys-prefix
 
 RUN git clone https://github.com/ivukotic/ML_platform_tests.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,7 @@ RUN . /release_setup.sh \
 
 RUN git clone https://github.com/ivukotic/ML_platform_tests.git
 
+# Have Jupyter shell setup AnalysisBase environment by default
+RUN echo -e '\n# Activate AnalysisBase environment on login shell\n. /release_setup.sh\n' >> /root/.bash_profile
+
 CMD ["/.run"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+build:
+	docker pull sslhep/analysis-dask-base:24.2.26
+	docker build \
+		--file Dockerfile \
+		--tag sslhep/analysis-dask-uc:24.2.26-debug \
+		.

--- a/private_jupyter_notebook_config.py
+++ b/private_jupyter_notebook_config.py
@@ -3,3 +3,5 @@ c.ServerApp.port = 9999
 # c.ServerApp.root_dir = ''
 c.ServerApp.allow_password_change = False
 c.NotebookApp.open_browser = False
+# Set shell to bash as AnalysisBase assumes it
+c.NotebookApp.terminado_settings = { "shell_command": ["/bin/bash"] }

--- a/private_jupyter_notebook_config.py
+++ b/private_jupyter_notebook_config.py
@@ -4,4 +4,5 @@ c.ServerApp.port = 9999
 c.ServerApp.allow_password_change = False
 c.NotebookApp.open_browser = False
 # Set shell to bash as AnalysisBase assumes it
-c.NotebookApp.terminado_settings = { "shell_command": ["/bin/bash"] }
+# force login shell to pickup ~/.bash_profile
+c.NotebookApp.terminado_settings = { "shell_command": ["/bin/bash", "-l"] }

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # . /environment
+
+# Setup AnalysisBase environment in the event "$@" doesn't create a new shell
+. /release_setup.sh
+
 echo $PATH
 echo "========= all set up. ============"
 ls


### PR DESCRIPTION
The container was getting stuck on startup on the AF (`feickert-notebook-1` was this project and `feickert-notebook-2` was one of the ML containers that was already supported, but started up right away)

![Screenshot from 2023-11-09 15-21-23](https://github.com/usatlas/analysisbase-dask-uc/assets/5142394/1421ce04-c5cb-45ab-bcd6-8a6fa5d12e1a)

This PR ensures that the `CMD` script is executable and then combines lines as shell manipulaitons are not persistent between `RUN` commands.

Additionally it also sets the base image to `sslhep/analysis-dask-base:24.2.26` instead of the `main` tag for stability and then ensures that the environment will be automatically setup correctly in the event that `"$@"` is _not_ a new shell like `/bin/bash`.

Examples:

* Get to Jupyter Lab environment after a new shell is created

```console
$ make
$ docker run --rm -ti --publish 9999:9999 sslhep/analysis-dask-uc:24.2.26-debug /bin/bash
[bash][root]:analysis > . /release_setup.sh 
Configured GCC from: /opt/lcg/gcc/11.2.0-8a51a/x86_64-centos7/bin/gcc
Configured AnalysisBase from: /usr/AnalysisBase/24.2.26/InstallArea/x86_64-centos7-gcc11-opt
(venv) [bash][root AnalysisBase-24.2.26]:analysis > jupyter lab --no-browser --allow-root  # --allow-root needed as user is root
```

* Get to Jupyter Lab environment from passing in command to `/.run`
(I assume that something like this is done by the pod?)

```console
$ make
$ docker run --rm -ti --publish 9999:9999 sslhep/analysis-dask-uc:24.2.26-debug /.run jupyter lab --no-browser --allow-root  # --allow-root needed as user is root
```

![image](https://github.com/usatlas/analysisbase-dask-uc/assets/5142394/a82f0792-875c-4765-bc04-a00b8d8c28ac)
