### PR TITLE
chore: Remove /release_setup.sh from CMD

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # . /environment
 
-# Setup AnalysisBase environment in the event "$@" doesn't create a new shell
-. /release_setup.sh
-
 echo $PATH
 echo "========= all set up. ============"
 ls


### PR DESCRIPTION
As /release_setup.sh is now controlled through the base image's ENTRYPOINT (c.f. https://github.com/usatlas/analysisbase-dask/pull/29) there is no need to source /release_setup.sh at CMD time, and so it can be removed.