### PR TITLE
fix: Set BASE_TAG build arg again before shell use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,11 @@ RUN mkdir /workspace
 COPY private_jupyter_notebook_config.py /root/.jupyter/jupyter_notebook_config.py
 
 COPY dask_config.yaml /etc/dask/dask_config.yaml
-RUN sed -i "s@\(.*image:\).*@\1 hub.opensciencegrid.org/usatlas/analysis-dask-base:${BASE_TAG}@" /etc/dask/dask_config.yaml;
+# Can't reuse value of BASE_IMAGE from FROM as this gets cleared by `docker build`, so just
+# reapply it here (only need to pass --build-arg BASE_TAG=... to docker build once).
+ARG BASE_TAG=latest
+RUN sed -i "s@\(.*image:\).*@\1 hub.opensciencegrid.org/usatlas/analysis-dask-base:${BASE_TAG}@" /etc/dask/dask_config.yaml \
+    && cat /etc/dask/dask_config.yaml
 
 
 RUN . /release_setup.sh \


### PR DESCRIPTION
* Resolves https://github.com/usatlas/analysisbase-dask/issues/32
* Fixes https://github.com/usatlas/analysisbase-dask-uc/commit/fcbecfe2d61d2d1abcccacf79a3225ca004abf17

Using a build arg as part of `FROM` will clear its value, so just reset the build arg again before it is needed to be used as a shell environment variable in a `RUN` command.