### PR TITLE
remove unused user sync script, add git completion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ RUN yum install -y jq
 
 RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
 
-RUN curl -L https://raw.githubusercontent.com/maniaclab/ci-connect-api/master/resources/provisioner/sync_users_debian.sh --output /sync_users_debian.sh
-RUN chmod +x /sync_users_debian.sh
-
+#RUN curl -L https://raw.githubusercontent.com/maniaclab/ci-connect-api/master/resources/provisioner/sync_users_debian.sh --output /sync_users_debian.sh
+#RUN chmod +x /sync_users_debian.sh
+RUN cp /usr/share/bash-completion/completions/git  /etc/profile.d/git.sh
 
 COPY run.sh  /.run
 RUN chmod +x /.run


### PR DESCRIPTION
Closes #12 
I think the user sync scripts are no longer used. I copied the git completion script to the /etc/profile.d directory. This should load the completion function for bash on startup. 