### PR TITLE
Relocate SetupPrivateJupyterLab.sh to /usr/local/bin/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN cp /usr/share/bash-completion/completions/git  /etc/profile.d/git.sh
 COPY run.sh  /.run
 RUN chmod +x /.run
 
-COPY SetupPrivateJupyterLab.sh /ML_platform_tests/SetupPrivateJupyterLab.sh
-RUN chmod +x /ML_platform_tests/SetupPrivateJupyterLab.sh
+COPY SetupPrivateJupyterLab.sh /usr/local/bin/SetupPrivateJupyterLab.sh
+RUN chmod +x /usr/local/bin/SetupPrivateJupyterLab.sh
 
 RUN mkdir /workspace
 # Want this to go to $(jupyter --config-dir) which is /root/.jupyter for this container
@@ -43,7 +43,7 @@ RUN . /release_setup.sh \
 RUN echo -e '\n# Activate AnalysisBase environment on login shell\n. /release_setup.sh\n' >> /root/.bash_profile
 
 # CMD given to container at runtime at UChicago Analysis Facility:
-# "/.run /ML_platform_tests/SetupPrivateJupyterLab.sh"
+# "/.run /usr/local/bin/SetupPrivateJupyterLab.sh"
 
 CMD ["/.run"]
 # ENTRYPOINT [ "/.run" ]

--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ When [configuring](https://af.uchicago.edu/jupyterlab/configure) the Jupyter Lab
 ```
 docker pull sslhep/analysis-dask-uc:latest
 ```
+
+## Container Layout
+
+The container is designed to be launched by the UChicago Analysis Facility JupyterHub service:
+
+- **Startup Script**: `SetupPrivateJupyterLab.sh` is installed at `/usr/local/bin/SetupPrivateJupyterLab.sh`
+- **Entrypoint**: The container entrypoint `/.run` executes any arguments passed to it
+- **Runtime Invocation**: The AF portal invokes the container with `/.run /usr/local/bin/SetupPrivateJupyterLab.sh`
+- **Startup Process**: The script creates a user account, configures the environment, and launches JupyterLab on port 9999


### PR DESCRIPTION
## Summary

- Update Dockerfile to install `SetupPrivateJupyterLab.sh` to `/usr/local/bin/` instead of `/ML_platform_tests/`
- This matches the path expected by the AF portal's `jupyterlab.py` configuration
- Add Container Layout section to README documenting runtime behavior

## Changes

**Dockerfile:**
- Line 21: Change COPY destination to `/usr/local/bin/SetupPrivateJupyterLab.sh`
- Line 22: Update chmod path to match new location
- Line 46: Update runtime comment with correct path

**README.md:**
- Add Container Layout section documenting how the AF portal invokes the container
- Document the startup script location, entrypoint behavior, and JupyterLab setup

## Test plan

- [ ] Build Docker image locally
- [ ] Verify script exists at `/usr/local/bin/SetupPrivateJupyterLab.sh`
- [ ] Verify old path `/ML_platform_tests/` no longer contains the script
- [ ] Test container launch at UChicago AF

🤖 Generated with [Claude Code](https://claude.com/claude-code)
